### PR TITLE
Update kubespawner property name

### DIFF
--- a/files/spawner.py
+++ b/files/spawner.py
@@ -258,10 +258,11 @@ class KubeFormSpawner(KubeSpawner):
         return options
 
     @property
-    def singleuser_image_spec(self):
+    def image(self):
         return self.user_options['image']
 
-    image_spec = singleuser_image_spec
+    image_spec = image
+    singleuser_image_spec = image
 
     @property
     def cpu_guarantee(self):


### PR DESCRIPTION
kubespawner deprecated the `image_spec` property name in 0.10, in favor of just a plain `image` property name. Update the `KubeFormSpawner` property with that naming, and proxy the deprecated names to the new property.

See https://github.com/kubeflow/kubeflow/pull/2508 for the corresponding upstream PR.