### PR TITLE
Update JupyterHub image to 1.0.0.dev

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,4 +26,4 @@ resources:
     type: oci-image
     description: 'Image used for JupyterHub'
     auto-fetch: true
-    upstream-source: 'docker.io/jupyterhub/jupyterhub:0.9.4'
+    upstream-source: 'docker.io/jupyterhub/jupyterhub:1.0.0.dev'

--- a/test_service.py
+++ b/test_service.py
@@ -30,7 +30,7 @@ def test_version():
 
     response = requests.get(f'{URL}/hub/api/')
     response.raise_for_status()
-    assert response.json() == {'version': '0.9.4'}
+    assert response.json() == {'version': '1.0.0.dev'}
 
 
 def test_jupyterhub():


### PR DESCRIPTION
We'll want to switch to 1.0.0 at some point, but for now, 0.9.4 has an issue with websockets that blocks notebooks from working.